### PR TITLE
correct uv_fs_mkstemp on windows

### DIFF
--- a/src/win/fs.c
+++ b/src/win/fs.c
@@ -763,88 +763,8 @@ void fs__mkdir(uv_fs_t* req) {
   SET_REQ_RESULT(req, result);
 }
 
-
-static void fs__mkdtemp_callback(uv_fs_t* req, static const size_t num_x, WCHAR* ep) {
-  size_t len;
-
-  if (_wmkdir(req->file.pathw) == 0) {
-    len = strlen(req->path);
-    wcstombs((char*) req->path + len - num_x, ep - num_x, num_x);
-    SET_REQ_RESULT(req, 0);
-    return 1;
-  } else if (errno != EEXIST) {
-    SET_REQ_RESULT(req, -1);
-    return 1;
-  }
-
-  return 0;
-}
-
-
-void fs__mkdtemp(uv_fs_t* req) {
-  fs__mktemp(req, fs__mkdtemp_callback);
-}
-
-
-int fs__mkstemp_callback(uv_fs_t* req, static const size_t num_x, WCHAR* ep) {
-  size_t len;
-  HANDLE file;
-  int fd;
-
-  file = CreateFileW(req->file.pathw,
-                     NULL,
-                     NULL,
-                     NULL,
-                     CREATE_NEW,
-                     FILE_ATTRIBUTE_TEMPORARY,
-                     NULL);
-
-  if (file == INVALID_HANDLE_VALUE) {
-    DWORD error;
-    error = GetLastError();
-
-    /* If the file exists, the main fs__mktemp() function
-       will retry. If it's another error, we want to stop. */
-    if (error != ERROR_FILE_EXISTS) {
-      SET_REQ_WIN32_ERROR(req, error);
-      return 1;
-    }
-
-    return 0;
-  }
-
-  len = strlen(req->path);
-  wcstombs((char*) req->path + len - num_x, ep - num_x, num_x);
-
-  fd = _open_osfhandle((intptr_t) file, flags);
-  if (fd < 0) {
-    /* The only known failure mode for _open_osfhandle() is EMFILE, in which
-     * case GetLastError() will return zero. However we'll try to handle other
-     * errors as well, should they ever occur.
-     */
-    if (errno == EMFILE)
-      SET_REQ_UV_ERROR(req, UV_EMFILE, ERROR_TOO_MANY_OPEN_FILES);
-    else if (GetLastError() != ERROR_SUCCESS)
-      SET_REQ_WIN32_ERROR(req, GetLastError());
-    else
-      SET_REQ_WIN32_ERROR(req, UV_UNKNOWN);
-    CloseHandle(file);
-    return 1;
-  }
-
-  SET_REQ_RESULT(req, fd);
-
-  return 1;
-}
-
-
-void fs__mkstemp(uv_fs_t* req) {
-  fs__mkstemp(req, fs__mkstemp_callback);
-}
-
-
 /* OpenBSD original: lib/libc/stdio/mktemp.c */
-void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_cb callback) {
+static void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_func callback) {
   static const WCHAR *tempchars =
     L"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   static const size_t num_chars = 62;
@@ -893,6 +813,84 @@ void fs__mktemp(uv_fs_t* req, uv__fs_mktemp_cb callback) {
   if (tries == 0) {
     SET_REQ_RESULT(req, -1);
   }
+}
+
+static int fs__mkdtemp_callback(uv_fs_t* req, size_t num_x, WCHAR* ep) {
+  size_t len;
+
+  if (_wmkdir(req->file.pathw) == 0) {
+    len = strlen(req->path);
+    wcstombs((char*) req->path + len - num_x, ep - num_x, num_x);
+    SET_REQ_RESULT(req, 0);
+    return 1;
+  } else if (errno != EEXIST) {
+    SET_REQ_RESULT(req, -1);
+    return 1;
+  }
+
+  return 0;
+}
+
+
+void fs__mkdtemp(uv_fs_t* req) {
+  fs__mktemp(req, fs__mkdtemp_callback);
+}
+
+
+static int fs__mkstemp_callback(uv_fs_t* req, size_t num_x, WCHAR* ep) {
+  size_t len;
+  HANDLE file;
+  int fd;
+
+  file = CreateFileW(req->file.pathw,
+                     GENERIC_READ | GENERIC_WRITE,
+                     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                     NULL,
+                     CREATE_NEW,
+                     FILE_ATTRIBUTE_NORMAL,
+                     NULL);
+
+  if (file == INVALID_HANDLE_VALUE) {
+    DWORD error;
+    error = GetLastError();
+
+    /* If the file exists, the main fs__mktemp() function
+       will retry. If it's another error, we want to stop. */
+    if (error != ERROR_FILE_EXISTS) {
+      SET_REQ_WIN32_ERROR(req, error);
+      return 1;
+    }
+
+    return 0;
+  }
+
+  len = strlen(req->path);
+  wcstombs((char*) req->path + len - num_x, ep - num_x, num_x);
+
+  fd = _open_osfhandle((intptr_t) file, 0);
+  if (fd < 0) {
+    /* The only known failure mode for _open_osfhandle() is EMFILE, in which
+     * case GetLastError() will return zero. However we'll try to handle other
+     * errors as well, should they ever occur.
+     */
+    if (errno == EMFILE)
+      SET_REQ_UV_ERROR(req, UV_EMFILE, ERROR_TOO_MANY_OPEN_FILES);
+    else if (GetLastError() != ERROR_SUCCESS)
+      SET_REQ_WIN32_ERROR(req, GetLastError());
+    else
+      SET_REQ_WIN32_ERROR(req, UV_UNKNOWN);
+    CloseHandle(file);
+    return 1;
+  }
+
+  SET_REQ_RESULT(req, fd);
+
+  return 1;
+}
+
+
+void fs__mkstemp(uv_fs_t* req) {
+  fs__mktemp(req,  fs__mkstemp_callback);
 }
 
 

--- a/src/win/internal.h
+++ b/src/win/internal.h
@@ -302,7 +302,7 @@ int uv_translate_sys_error(int sys_errno);
  * FS
  */
 void uv_fs_init();
-typedef int (*uv__fs_mktemp_func)(uv_fs_t* req, static const size_t num_x, WCHAR *ep);
+typedef int (*uv__fs_mktemp_func)(uv_fs_t* req, size_t num_x, WCHAR *ep);
 
 
 /*


### PR DESCRIPTION
I've corrected the windows code for you ( https://github.com/libuv/libuv/pull/729 )
I can see a few failing test cases on windows, but fs_mkdtemp and fs_mkstemp work as intended.
